### PR TITLE
Removed ? button on some dialog's title bar

### DIFF
--- a/src/gui/EasyDialog.cpp
+++ b/src/gui/EasyDialog.cpp
@@ -8,7 +8,7 @@ namespace gui
 {
 
 EasyDialog::EasyDialog(const QString& aTitle, QWidget* aParent, bool aIsModal)
-    : QDialog(aParent)
+    : QDialog(aParent, Qt::WindowTitleHint | Qt::WindowSystemMenuHint | Qt::WindowCloseButtonHint)
     , mLayout()
     , mOk()
 {


### PR DESCRIPTION
This patch removes '?' button at EasyDialog-based windows' title bar on Windows.
<img width="223" alt="2017-04-15" src="https://cloud.githubusercontent.com/assets/1283235/25064072/a1641ea8-222d-11e7-9cab-98e82cbc4f29.png">
