### PR TITLE
Add hardware encoding export preset.

### DIFF
--- a/data/encode/VideoEncode.txt
+++ b/data/encode/VideoEncode.txt
@@ -10,6 +10,12 @@
         <codec name="mpeg4" label="MPEG-4" icodec="ppm" hint="colorspace"
         command="-y -f image2pipe -framerate $ifps -c:v $icodec -i - -b:v $obps -r $ofps -c:v $ocodec $arg_colorfilter $arg_colorspace $opath" />
 
+        <codec name="h264_nvenc" label="H.264(NVENC)" icodec="ppm" hint="colorspace"
+        command="-y -f image2pipe -framerate $ifps -c:v $icodec -i - -b:v $obps -r $ofps -c:v $ocodec -preset llhq -rc ll_2pass_quality -subq 7 -pix_fmt yuv444p $arg_colorfilter $arg_colorspace $opath" />
+
+        <codec name="h264_qsv" label="H.264(QSV)" icodec="ppm" hint="colorspace"
+        command="-y -f image2pipe -framerate $ifps -c:v $icodec -i - -b:v $obps -r $ofps -c:v $ocodec -preset slower -subq 7 -pix_fmt yuv444p $arg_colorfilter $arg_colorspace -look_ahead 0 $opath" />
+
     </format>
     <format name="webm" label="WebM">
         <codec name="libvpx-vp9" label="VP9" icodec="ppm" hint="colorspace"
@@ -36,6 +42,12 @@
     <format name="mov" label="MOV">
         <codec name="libx264" label="H.264" icodec="ppm" hint="colorspace"
         command="-y -f image2pipe -framerate $ifps -c:v $icodec -i - -b:v $obps -r $ofps -c:v $ocodec -pix_fmt yuv444p $arg_colorfilter $arg_colorspace $opath" />
+
+        <codec name="h264_nvenc" label="H.264(NVENC)" icodec="ppm" hint="colorspace"
+        command="-y -f image2pipe -framerate $ifps -c:v $icodec -i - -b:v $obps -r $ofps -c:v $ocodec -preset llhq -rc ll_2pass_quality -subq 7 -pix_fmt yuv444p $arg_colorfilter $arg_colorspace $opath" />
+
+        <codec name="h264_qsv" label="H.264(QSV)" icodec="ppm" hint="colorspace"
+        command="-y -f image2pipe -framerate $ifps -c:v $icodec -i - -b:v $obps -r $ofps -c:v $ocodec -preset slower -subq 7 -pix_fmt yuv444p $arg_colorfilter $arg_colorspace -look_ahead 0 $opath" />
 
         <codec name="prores_ks" label="ProRes" icodec="png" hint="transparent"
         command="-y -f image2pipe -framerate $ifps -c:v $icodec -i - -b:v $obps -r $ofps -profile:v 4444 -c:v $ocodec $opath" />


### PR DESCRIPTION
Add general hardware encoding options for MP4 and MOV export. (NVENC & QSV)
It's decrease 20~30% CPU usage than software encode on FFMPEG ver.3.2.4 :)